### PR TITLE
Translation improvements

### DIFF
--- a/website/public/locales/fr.json
+++ b/website/public/locales/fr.json
@@ -4,7 +4,7 @@
     "inputSecretLabel": "Message secret",
     "inputSecretPlaceholder": "Message à chiffrer localement dans votre navigateur",
     "buttonEncrypt": "Chiffrer le message",
-    "buttonEncryptLoading": "Message en cours de chiffrement...",
+    "buttonEncryptLoading": "Message en cours de chiffrement…",
     "inputOneTimeLabel": "Téléchargement unique",
     "inputPasswordLabel": "Clé de déchiffrement personnalisée",
     "inputGenerateLabel": "Générer une clé de déchiffrement"
@@ -15,10 +15,10 @@
     "errorFileTooLarge": "Le fichier est trop volumineux."
   },
   "display": {
-    "titleFetching": "Réccupération à partir de la base de données, veuillez tenir ...",
-    "titleDecrypting": "Déchiffrement en cours, veuillez patienter...",
+    "titleFetching": "Récupération à partir de la base de données, veuillez patienter…",
+    "titleDecrypting": "Déchiffrement en cours, veuillez patienter",
     "titleDecryptionKey": "Entrer la clé de déchiffrement",
-    "captionDecryptionKey": "Veuillez ne pas rafraîchir cette fenêtre: le secret pourrait être limité à un téléchargement unique.",
+    "captionDecryptionKey": "Veuillez ne pas rafraîchir cette fenêtre : le secret pourrait être limité à un téléchargement unique.",
     "inputDecryptionKeyPlaceholder": "Clé de déchiffrement",
     "inputDecryptionKeyLabel": "Une clé de déchiffrement est requise, veuillez l'indiquer.",
     "errorInvalidPassword": "Mot de passe invalide, veuillez réessayer",
@@ -28,8 +28,8 @@
     "title": "Le secret n'existe pas",
     "subtitle": "Cela peut être causé par une des raisons suivantes.",
     "titleOpened": "Ouvert auparavant",
-    "subtitleOpenedBefore": "Un secret peut être limité à un seul téléchargement. Il peut être perdu car l'expéditeur a cliqué sur ce lien avant de le voir.",
-    "subtitleOpenedCompromised": "Le secret aurait pu être compromis et lu par quelqu'un d'autre. Vous devriez contacter l'expéditeur et demander un nouveau secret.",
+    "subtitleOpenedBefore": "Un secret peut être limité à un seul téléchargement. Il peut être perdu car l'expéditeur a cliqué sur ce lien avant vous.",
+    "subtitleOpenedCompromised": "Le secret a pu être compromis et lu par quelqu'un d'autre. Vous devriez contacter l'expéditeur et demander un nouveau secret.",
     "titleBrokenLink": "Lien brisé",
     "subtitleBrokenLink": "Le lien doit correspondre parfaitement afin que le déchiffrement fonctionne, il pourrait manquer des caractères.",
     "titleExpired": "Expiré",
@@ -38,7 +38,7 @@
   "result": {
     "title": "Secret stocké dans la base de données",
     "subtitleDownloadOnce": "N'oubliez pas que les secrets ne peuvent être téléchargés qu'une seule fois s'ils ne sont pas définis autrement. Alors n'ouvrez pas le lien vous-même.",
-    "subtitleChannel": "Le prudent devrait envoyer la clé de déchiffrement dans un canal de communication distinct.",
+    "subtitleChannel": "Il serait prudent d'envoyer la clé de déchiffrement via un canal de communication distinct.",
     "rowLabelOneClick": "Lien unique",
     "rowLabelShortLink": "Lien court",
     "rowLabelDecryptionKey": "Clé de déchiffrement"
@@ -46,15 +46,15 @@
   "secret": {
     "titleFile": "Fichier téléchargé",
     "titleMessage": "Message déchiffré",
-    "subtitleMessage": "Ce secret pourrait ne pas être à nouveau visible, assurez-vous de le sauver maintenant!",
+    "subtitleMessage": "Ce secret pourrait ne plus jamais être visible, assurez-vous de l'enregistrer maintenant !",
     "buttonCopy": "Copier"
   },
   "delete": {
     "buttonDelete": "Supprimer",
-    "messageDeleted": "Le secret est supprimé du serveur!",
-    "dialogTitle": "Supprimer le secret?",
-    "dialogMessage": "Êtes-vous sûr de vouloir supprimer ce secret?",
-    "dialogProgress": "Suppression...",
+    "messageDeleted": "Le secret est supprimé du serveur !",
+    "dialogTitle": "Supprimer le secret ?",
+    "dialogMessage": "Êtes-vous sûr.e de vouloir supprimer ce secret ?",
+    "dialogProgress": "Suppression…",
     "dialogConfirm": "Supprimer",
     "dialogCancel": "Annuler"
   },
@@ -72,7 +72,7 @@
   },
   "features": {
     "title": "Partagez facilement les secrets en toute sécurité",
-    "subtitle": "Yopass est créé pour réduire la quantité de mots de passe de textes clairs stockés par e-mail et dans les conversations chat en chiffrant et en générant un lien de courte durée qui ne peut être affiché qu'une seule fois.",
+    "subtitle": "Yopass est créé pour réduire la quantité de mots de passe échangés en clair par e-mail et par les messageries instantanées en chiffrant et en générant un lien de courte durée qui ne peut être affiché qu'une seule fois.",
     "featureEndToEndTitle": "Chiffrement de bout en bout",
     "featureEndToEndText": "Le chiffrement et le déchiffrement se réalisent localement dans le navigateur. La clé n'est jamais stockée avec Yopass.",
     "featureSelfDestructionTitle": "Auto destruction",
@@ -80,11 +80,11 @@
     "featureOneTimeTitle": "Téléchargements uniques",
     "featureOneTimeText": "Le message chiffré ne peut être téléchargé qu'une seule fois, ce qui réduit le risque que quelqu'un ait jeté un coup d'œil à vos secrets.",
     "featureSimpleSharingTitle": "Partage simple",
-    "featureSimpleSharingText": "Yopass génère un lien unique de clics pour le fichier ou le message chiffré. Le mot de passe de déchiffrement peut également être envoyé séparément.",
+    "featureSimpleSharingText": "Yopass génère un lien à usage unique pour le fichier ou le message chiffré. Le mot de passe de déchiffrement peut également être envoyé séparément.",
     "featureNoAccountsTitle": "Aucun compte nécessaire",
-    "featureNoAccountsText": "Le partage doit être rapide et facile; Aucune information supplémentaire, seul le secret chiffré est stocké dans la base de données.",
+    "featureNoAccountsText": "Le partage doit être rapide et facile ; aucune information supplémentaire, seul le secret chiffré est stocké dans la base de données.",
     "featureOpenSourceTitle": "Logiciel open source",
-    "featureOpenSourceText": "Le mécanisme de chiffrement Yopass est construit sur des logiciels open source, ce qui signifie une transparence complète avec la possibilité d'auditer et de soumettre des fonctionnalités."
+    "featureOpenSourceText": "Le mécanisme de chiffrement Yopass est construit sur des logiciels open source, ce qui garantit une transparence complète avec la possibilité d'auditer et de soumettre des fonctionnalités."
   },
   "header": {
     "buttonHome": "Accueil",

--- a/website/public/locales/fr.json
+++ b/website/public/locales/fr.json
@@ -33,7 +33,7 @@
     "titleBrokenLink": "Lien brisé",
     "subtitleBrokenLink": "Le lien doit correspondre parfaitement afin que le déchiffrement fonctionne, il pourrait manquer des caractères.",
     "titleExpired": "Expiré",
-    "subtitleExpired": "Aucun secret dure pour toujours. Tous les secrets stockés expirent et s'auto-détruisent automatiquement. Leur durée de vie varie d'une heure à une semaine."
+    "subtitleExpired": "Aucun secret ne dure pour toujours. Tous les secrets stockés expirent et s'auto-détruisent automatiquement. Leur durée de vie varie d'une heure à une semaine."
   },
   "result": {
     "title": "Secret stocké dans la base de données",


### PR DESCRIPTION
Let me suggest some improvements to your already nice version:

- characters such as `:`, `;`, `!` or `?` should be preceded by a non-breaking space in French typography
- it is best to use an ellipsis character `…` in place of three periods `...` because it guarantees that a line break cannot split the series of glyphs. I know it is _already_ wrong in the English language file, but I may consider submitting a PR there as well :)
- I proposed some minor changes here and there that make the sentences look more French to my French eyes
- I fixed a typo in "récupération"